### PR TITLE
Added GET /group/membership support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,3 +66,4 @@ to the end of this list and include the change in your pull request.
 * Dan Hansen (@dansomething)
 * Terin Stock (@terinjokes)
 * Sorin Sbarnea (@ssbarnea)
+* Attila Bogár (@attilabogar)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     license='BSD',
     py_modules=['crowd'],
     version='0.8',
-    install_requires=['requests'],
+    install_requires=['requests', 'lxml'],
 
     description='A python client to the Atlassian Crowd REST API',
     long_description=open(os.path.join(__dir__, 'README.rst')).read(),


### PR DESCRIPTION
Hi,

I've added support for GET /group/membership support to dump the whole membership associations database.
https://developer.atlassian.com/display/CROWDDEV/Crowd+REST+Resources

A bit ugly, but works. ;-)

I've authored a gitolite crowd integration module, I'm going to publish that soon.
This will be an example usage fort this feature.

Regards,
  Attila
