### PR TITLE
Add contributors license agreement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,11 @@ TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
 DAMAGE.
 
+Contributors License Agreement
+==============================
+
+By contributing you agree that these contributions are your own (or approved by your employer) and you grant a full, complete, irrevocable copyright license to all users and developers of the project, present and future, pursuant to the license of the project.
+
 Contributors
 ============
 


### PR DESCRIPTION
This PR introduces a Contributors License Agreement that will apply to all contributions to the python-crowd project. This is in line with various other open source projects (this particular CLA uses the language of the Ansible CLA).

Previously we've sought agreement from contributors to re-license the project under the BSD 2-clause license (see issue #11). I'm now asking prior contributors to agree to this CLA retroactively to their previous commits as well as future work. Note that the CLA applies in addition to the BSD 2-clause license.

If you agree then please add a comment to this issue stating so.
@ssbarnea @terinjokes @dansomething @lukecyca @akarnani

I haven't made changes to this project for a while in part due to the relation of my employment and the python-crowd module (and I feel bad about letting things slide this long). This CLA clarifies the status of contributions to this project, which helps resolve the complications in relation to my work but also in relation to the use of python-crowd (or forked works) in other projects.